### PR TITLE
Add transformers import handling

### DIFF
--- a/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/statement.rs
@@ -953,6 +953,12 @@ pub(crate) fn statement(stmt: &Stmt, checker: &mut Checker) {
             if checker.enabled(Rule::ByteStringUsage) {
                 flake8_pyi::rules::bytestring_import(checker, import_from);
             }
+            if checker.enabled(Rule::ExplicitRelativeImport) {
+                ruff::rules::transformers::rules::explicit_relative_import(checker, stmt, import_from);
+            }
+            if checker.enabled(Rule::UnwrapInheritance) {
+                ruff::rules::transformers::rules::unwrap_import_from(checker, stmt, import_from);
+            }
         }
         Stmt::Raise(raise @ ast::StmtRaise { exc, .. }) => {
             if checker.enabled(Rule::RaiseNotImplemented) {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1029,6 +1029,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "060") => (RuleGroup::Preview, rules::ruff::rules::InEmptyCollection),
         (Ruff, "061") => (RuleGroup::Preview, rules::ruff::rules::LegacyFormPytestRaises),
         (Ruff, "062") => (RuleGroup::Preview, rules::ruff::rules::UnwrapInheritance),
+        (Ruff, "063") => (RuleGroup::Preview, rules::transformers::rules::ExplicitRelativeImport),
         (Ruff, "100") => (RuleGroup::Stable, rules::ruff::rules::UnusedNOQA),
         (Ruff, "101") => (RuleGroup::Stable, rules::ruff::rules::RedirectedNOQA),
         (Ruff, "102") => (RuleGroup::Preview, rules::ruff::rules::InvalidRuleCode),

--- a/crates/ruff_linter/src/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/mod.rs
@@ -56,4 +56,5 @@ pub mod pylint;
 pub mod pyupgrade;
 pub mod refurb;
 pub mod ruff;
+pub mod transformers;
 pub mod tryceratops;

--- a/crates/ruff_linter/src/rules/transformers/rules/explicit_relative_import.rs
+++ b/crates/ruff_linter/src/rules/transformers/rules/explicit_relative_import.rs
@@ -1,0 +1,49 @@
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_ast::{self as ast, Alias, Identifier, Stmt, StmtImportFrom};
+use ruff_text_size::{Ranged, TextRange};
+
+use crate::checkers::ast::Checker;
+use crate::{Edit, Fix, FixAvailability, Violation};
+
+#[derive(ViolationMetadata)]
+pub(crate) struct ExplicitRelativeImport;
+
+impl Violation for ExplicitRelativeImport {
+    const FIX_AVAILABILITY: FixAvailability = FixAvailability::Always;
+
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        "Relative imports should specify a module".to_string()
+    }
+
+    fn fix_title(&self) -> Option<String> {
+        Some("Specify module in import".to_string())
+    }
+}
+
+pub(crate) fn explicit_relative_import(checker: &Checker, stmt: &Stmt, import: &StmtImportFrom) {
+    if import.level == 0 || import.module.is_some() {
+        return;
+    }
+    let Some(stem) = checker.path().file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    let module_name = if let Some(rest) = stem.strip_prefix("modular_") {
+        format!("modeling_{rest}")
+    } else {
+        stem.to_string()
+    };
+
+    let node = ast::StmtImportFrom {
+        module: Some(Identifier::new(module_name.clone(), TextRange::default())),
+        names: import.names.clone(),
+        level: import.level,
+        range: TextRange::default(),
+        node_index: ast::AtomicNodeIndex::dummy(),
+    };
+    let mut diagnostic = checker.report_diagnostic(ExplicitRelativeImport, stmt.range());
+    diagnostic.set_fix(Fix::safe_edit(Edit::range_replacement(
+        checker.generator().stmt(&node.into()),
+        stmt.range(),
+    )));
+}

--- a/crates/ruff_linter/src/rules/transformers/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/transformers/rules/mod.rs
@@ -1,0 +1,5 @@
+pub(crate) use unwrap_inheritance::*;
+pub(crate) use explicit_relative_import::*;
+
+mod unwrap_inheritance;
+mod explicit_relative_import;

--- a/crates/ruff_linter/src/rules/transformers/rules/unwrap_inheritance.rs
+++ b/crates/ruff_linter/src/rules/transformers/rules/unwrap_inheritance.rs
@@ -1,8 +1,11 @@
 use rustc_hash::FxHashSet;
-use ruff_macros::{ViolationMetadata, derive_message_formats};
-use ruff_python_ast::{self as ast, helpers::is_docstring_stmt, whitespace::trailing_lines_end, whitespace::indentation, Stmt, StmtClassDef};
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_ast::{self as ast, helpers::is_docstring_stmt, whitespace::indentation, whitespace::trailing_lines_end, Stmt, StmtClassDef, StmtImportFrom};
+use ruff_python_codegen::{Generator, Stylist};
+use ruff_python_parser::parse_module;
 use ruff_python_trivia::textwrap::indent;
 use ruff_text_size::Ranged;
+use std::{fs, path::{Path, PathBuf}};
 
 use crate::checkers::ast::Checker;
 use crate::{Edit, Fix, Violation};
@@ -128,5 +131,133 @@ pub(crate) fn unwrap_inheritance(checker: &Checker, class_def: &StmtClassDef) {
                 Ok(Fix::unsafe_edits(edits.remove(0), edits))
             });
         }
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+fn rename_modeling(content: &str, from: &str, to: &str) -> String {
+    let camel_from = capitalize(from);
+    let camel_to = capitalize(to);
+    content
+        .replace(&camel_from, &camel_to)
+        .replace(&from.to_ascii_uppercase(), &to.to_ascii_uppercase())
+        .replace(from, to)
+}
+
+fn modeling_name_from_path(path: &Path) -> Option<String> {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .and_then(|stem| stem.strip_prefix("modeling_"))
+        .map(|s| s.to_string())
+}
+
+fn resolve_module_path(path: &Path, level: usize, module: Option<&str>) -> PathBuf {
+    let mut result = path.parent().unwrap_or(path).to_path_buf();
+    for _ in 0..level.saturating_sub(1) {
+        result = result.parent().unwrap_or(&result).to_path_buf();
+    }
+    if let Some(module) = module {
+        for part in module.split('.') {
+            result.push(part);
+        }
+    }
+    result.set_extension("py");
+    result
+}
+
+fn load_statement_source(
+    path: &Path,
+    name: &str,
+    rename_from: Option<&str>,
+    rename_to: Option<&str>,
+    stylist: &Stylist,
+) -> Option<String> {
+    let source = fs::read_to_string(path).ok()?;
+    let parsed = parse_module(&source).ok()?;
+    let generator = Generator::from(stylist);
+    for stmt in parsed.into_suite() {
+        match &stmt {
+            Stmt::ClassDef(ast::StmtClassDef { name: ident, .. })
+            | Stmt::FunctionDef(ast::StmtFunctionDef { name: ident, .. })
+            | Stmt::AsyncFunctionDef(ast::StmtAsyncFunctionDef { name: ident, .. }) => {
+                if ident.as_str() == name {
+                    let mut content = generator.stmt(&stmt);
+                    if let (Some(from), Some(to)) = (rename_from, rename_to) {
+                        content = rename_modeling(&content, from, to);
+                    }
+                    return Some(content);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+pub(crate) fn unwrap_import_from(checker: &Checker, stmt: &Stmt, import: &StmtImportFrom) {
+    let module = import.module.as_deref();
+    if checker.settings.ruff.unwrap_inheritance_modules.is_empty() {
+        return;
+    }
+    if module.is_none() {
+        return;
+    }
+    let module = module.unwrap();
+    if !checker
+        .settings
+        .ruff
+        .unwrap_inheritance_modules
+        .iter()
+        .any(|prefix| module.starts_with(prefix))
+    {
+        return;
+    }
+
+    let from_name = module
+        .rsplit_once('_')
+        .map(|(_, name)| name)
+        .unwrap_or(module);
+    let to_name = modeling_name_from_path(checker.path());
+
+    let mut edits = Vec::new();
+    let mut names = Vec::new();
+    for alias in &import.names {
+        if &alias.name == "*" {
+            continue;
+        }
+        let name = alias.asname.as_ref().unwrap_or(&alias.name).as_str();
+        let path = resolve_module_path(checker.path(), import.level as usize, Some(module));
+        if let Some(to_name) = to_name.as_deref() {
+            if let Some(content) = load_statement_source(&path, alias.name.as_str(), Some(from_name), Some(to_name), checker.stylist()) {
+                edits.push(Edit::insertion(format!("{}{}", checker.stylist().line_ending(), content), stmt.end()));
+            }
+        } else if let Some(content) = load_statement_source(&path, alias.name.as_str(), None, None, checker.stylist()) {
+            edits.push(Edit::insertion(format!("{}{}", checker.stylist().line_ending(), content), stmt.end()));
+        }
+        names.push(name);
+    }
+
+    if names.is_empty() {
+        return;
+    }
+
+    if let Ok(remove_edit) = crate::fix::edits::remove_unused_imports(
+        names.iter().copied(),
+        stmt,
+        checker.semantic().current_statement_parent(),
+        checker.locator(),
+        checker.stylist(),
+        checker.indexer(),
+    ) {
+        checker.report_diagnostic(UnwrapInheritance { base: module.to_string() }, stmt.range()).try_set_fix(|| {
+            Ok(Fix::unsafe_edits(remove_edit, edits))
+        });
     }
 }


### PR DESCRIPTION
## Summary
- implement functions to rename modeling identifiers and resolve module paths
- extend transformers rules with an explicit relative import rule
- support unwrapping imports from modeling modules
- integrate new rules into statement analysis

## Testing
- `cargo test -p ruff_linter --no-run` *(fails: failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68549a0600d0832fb67e2f6d1eba9e54