### PR TITLE
Add modular class prefix rule

### DIFF
--- a/crates/ruff_linter/resources/test/fixtures/ruff/modular_RUF064.py
+++ b/crates/ruff_linter/resources/test/fixtures/ruff/modular_RUF064.py
@@ -1,0 +1,2 @@
+class Attention:
+    pass

--- a/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
+++ b/crates/ruff_linter/src/checkers/ast/analyze/deferred_scopes.rs
@@ -390,6 +390,9 @@ pub(crate) fn deferred_scopes(checker: &Checker) {
             if checker.enabled(Rule::UnwrapInheritance) {
                 transformers::rules::unwrap_inheritance(checker, class_def);
             }
+            if checker.enabled(Rule::ClassNamePrefix) {
+                transformers::rules::class_name_prefix(checker, class_def);
+            }
         }
 
         if matches!(scope.kind, ScopeKind::Function(_) | ScopeKind::Lambda(_)) {

--- a/crates/ruff_linter/src/codes.rs
+++ b/crates/ruff_linter/src/codes.rs
@@ -1030,6 +1030,7 @@ pub fn code_to_rule(linter: Linter, code: &str) -> Option<(RuleGroup, Rule)> {
         (Ruff, "061") => (RuleGroup::Preview, rules::ruff::rules::LegacyFormPytestRaises),
         (Ruff, "062") => (RuleGroup::Preview, rules::transformers::rules::UnwrapInheritance),
         (Ruff, "063") => (RuleGroup::Preview, rules::transformers::rules::ExplicitRelativeImport),
+        (Ruff, "064") => (RuleGroup::Preview, rules::transformers::rules::ClassNamePrefix),
         (Ruff, "100") => (RuleGroup::Stable, rules::ruff::rules::UnusedNOQA),
         (Ruff, "101") => (RuleGroup::Stable, rules::ruff::rules::RedirectedNOQA),
         (Ruff, "102") => (RuleGroup::Preview, rules::ruff::rules::InvalidRuleCode),

--- a/crates/ruff_linter/src/rules/transformers/mod.rs
+++ b/crates/ruff_linter/src/rules/transformers/mod.rs
@@ -16,6 +16,7 @@ mod tests {
     use crate::test::test_path;
 
     #[test_case(Rule::ExplicitRelativeImport, Path::new("RUF063.py"))]
+    #[test_case(Rule::ClassNamePrefix, Path::new("modular_RUF064.py"))]
     fn rules(rule_code: Rule, path: &Path) -> Result<()> {
         let snapshot = format!("{}_{}", rule_code.noqa_code(), path.to_string_lossy());
         let diagnostics = test_path(Path::new("ruff").join(path).as_path(), &LinterSettings::for_rule(rule_code))?;

--- a/crates/ruff_linter/src/rules/transformers/rules/class_name_prefix.rs
+++ b/crates/ruff_linter/src/rules/transformers/rules/class_name_prefix.rs
@@ -1,0 +1,46 @@
+use ruff_macros::{derive_message_formats, ViolationMetadata};
+use ruff_python_ast::{self as ast, StmtClassDef};
+use ruff_text_size::Ranged;
+
+use crate::checkers::ast::Checker;
+use crate::Violation;
+
+#[derive(ViolationMetadata)]
+pub(crate) struct ClassNamePrefix {
+    expected: String,
+}
+
+impl Violation for ClassNamePrefix {
+    #[derive_message_formats]
+    fn message(&self) -> String {
+        let Self { expected } = self;
+        format!("Class name should start with `{expected}`")
+    }
+}
+
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(c) => c.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+/// RUF064
+pub(crate) fn class_name_prefix(checker: &Checker, class_def: &StmtClassDef) {
+    let Some(stem) = checker.path().file_stem().and_then(|s| s.to_str()) else {
+        return;
+    };
+    let Some(model) = stem.strip_prefix("modular_") else {
+        return;
+    };
+    let expected = capitalize(model);
+    if !class_def.name.starts_with(&expected) {
+        checker.report_diagnostic(
+            ClassNamePrefix {
+                expected: expected.clone(),
+            },
+            class_def.range(),
+        );
+    }
+}

--- a/crates/ruff_linter/src/rules/transformers/rules/mod.rs
+++ b/crates/ruff_linter/src/rules/transformers/rules/mod.rs
@@ -1,5 +1,7 @@
 pub(crate) use unwrap_inheritance::*;
 pub(crate) use explicit_relative_import::*;
+pub(crate) use class_name_prefix::*;
 
 mod unwrap_inheritance;
 mod explicit_relative_import;
+mod class_name_prefix;

--- a/docs/modular.md
+++ b/docs/modular.md
@@ -1,0 +1,23 @@
+# Modular model rules
+
+Ruff includes preview rules for validating modular model files. These files are expected to be named `modular_<model>.py` and generate a `modeling_<model>.py` file when the rules are fixed.
+
+The linter enforces:
+
+- `RUF062` – unwrap inheritance to inline parent class members.
+- `RUF063` – expand relative imports inside the file.
+- `RUF064` – every class name must start with the model name derived from the file name.
+
+## Running the rules
+
+Use `ruff check` with the Transformers rules enabled:
+
+```console
+$ ruff check modular_llama.py --select RUF062,RUF063,RUF064
+```
+
+Applying the rules with `--fix` will emit a `modeling_<model>.py` file with the transformations applied:
+
+```console
+$ ruff check modular_llama.py --select RUF062,RUF063,RUF064 --fix > modeling_llama.py
+```


### PR DESCRIPTION
## Summary
- enforce modular class name prefixes with new `ClassNamePrefix` rule
- document how to run the transformers rules

## Testing
- `cargo test` *(fails: failed to fetch dependencies)*
- `uvx pre-commit run --all-files --show-diff-on-failure` *(fails: failed to fetch pre-commit)*
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6855288ff9e0832fb64008d6ab4e25f3